### PR TITLE
Add locale messages & Change current locale in store

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ export IntlProvider from './components/IntlProvider'
 export Provider from './components/Provider'
 
 export const UPDATE = '@@intl/UPDATE'
+export const ADD = '@@intl/ADD'
+export const CHANGE = '@@intl/CHANGE'
 
 export const updateIntl = ({locale, messages}) => ({
   type: UPDATE,
@@ -15,15 +17,47 @@ export const update = (intl) => {
   return updateIntl(intl)
 }
 
+// add messages to locale store. Doesn't update selected locale.
+export const addIntl = ({locale, messages}) => ({
+  type: ADD,
+  payload: { locale, messages },
+})
+
+// changes selected locale.
+export const changeLocale = (locale) => ({
+  type: CHANGE,
+  payload: { locale },
+})
+
 const initialState = {
   locale: 'en',
   messages: {},
+  localeStore: {}
 }
 
 export function intlReducer(state = initialState, action) {
-  if (action.type !== UPDATE) {
-    return state
+  const localeStore = state.localeStore
+  if (action.type === ADD) {
+    const payloadLocale = action.payload.locale
+    if (payloadLocale in localeStore) {
+      let locale1 = localeStore[payloadLocale]
+      locale1.messages = Object.assign({}, locale1.messages, action.payload.messages)
+    } else {
+      localeStore[payloadLocale] = action.payload
+    }
+    if (state.locale === payloadLocale) {
+      state.messages = Object.assign({}, state.messages, action.payload.messages)
+    }
+    return Object.assign({}, state)
   }
-
-  return { ...state, ...action.payload }
+  if (action.type === CHANGE) {
+    const payloadLocale = action.payload.locale
+    if (payloadLocale in localeStore) {
+      return {...state, ...state.localeStore[payloadLocale] }
+    }
+  }
+  if (action.type === UPDATE) {
+    return { ...state, ...action.payload }
+  }
+  return state
 }


### PR DESCRIPTION
With reference to https://github.com/yahoo/react-intl/issues/106. In case of component level i18n updateIntl action creator replaces current locale & messages. addIntl & changeLocale action creators will add messages without removing existing and change locale on demand without 
removing loaded messages in store.
