### PR TITLE
Export initial state so it can be extended.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export const update = (intl) => {
   return updateIntl(intl)
 }
 
-const initialState = {
+export const initialState = {
   locale: 'en',
   messages: {},
 }

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -1,13 +1,10 @@
 import should from 'should'
 
-import {intlReducer} from '../src'
+import {initialState, intlReducer, UPDATE} from '../src'
 
 describe('intlReducer', () => {
   it('should set initial state', () => {
-    should(intlReducer(undefined, {})).be.eql({
-      locale: 'en',
-      messages: {},
-    })
+    should(intlReducer(undefined, {})).be.eql(initialState)
   })
 
   it('can update state', () => {
@@ -16,7 +13,7 @@ describe('intlReducer', () => {
       messages: {},
     }
     const action = {
-      type: '@@intl/UPDATE',
+      type: UPDATE,
       payload,
     }
     should(intlReducer(undefined, action)).be.eql(payload)


### PR DESCRIPTION
The reason for this change is so the intlReducer can be extended. In this way you can wrap the intlReducer function with a function that receives the extended initial state without having to duplicate the initial state structure. Let me know what you think of this change. Thank you!