### PR TITLE
update for react-redux@5.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "peerDependencies": {
     "react-intl": "^2.2.2",
-    "react-redux": "^5.0.1"
+    "react-redux": "^5.0.3"
   },
   "dependencies": {
     "warning": "^3.0.0"

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -1,6 +1,6 @@
 import {Provider as ReduxProvider} from 'react-redux'
 import React, {PropTypes} from 'react'
-import storeShape from 'react-redux/lib/utils/storeShape'
+import {storeShape} from 'react-redux/lib/utils/PropTypes'
 
 import IntlProvider from './IntlProvider'
 


### PR DESCRIPTION
React-redux 5.0.3 breaks react-intl-redux. Provider.js imported storeShape from react-redux/lib/utils/storeShape. This file has been renamed to react-redux/lib/utils/PropTypes.

5.0.2: https://github.com/reactjs/react-redux/blob/v5.0.2/src/utils/storeShape.js
5.0.3: https://github.com/reactjs/react-redux/blob/v5.0.3/src/utils/PropTypes.js

All tests are passing. Let me know if anything should be changed.

Thanks!