### PR TITLE
Support React 15.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-intl-redux",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Redux binding for React Intl",
   "main": "lib/index",
   "scripts": {
@@ -16,6 +16,7 @@
     "react-redux": "^5.0.1"
   },
   "dependencies": {
+    "prop-types": "^15.5.8",
     "warning": "^3.0.0"
   },
   "devDependencies": {

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -1,5 +1,6 @@
 import {Provider as ReduxProvider} from 'react-redux'
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types';
 
 import IntlProvider from './IntlProvider'
 


### PR DESCRIPTION
Using the prop-types package to remove depreciation warning from React package.