### PR TITLE
Include formats in updateIntl (#24)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,9 @@ export Provider from './components/Provider'
 
 export const UPDATE = '@@intl/UPDATE'
 
-export const updateIntl = ({locale, messages}) => ({
+export const updateIntl = ({locale, formats, messages}) => ({
   type: UPDATE,
-  payload: {locale, messages},
+  payload: {locale, formats, messages},
 })
 
 export const update = (intl) => {

--- a/test/actions.spec.js
+++ b/test/actions.spec.js
@@ -8,7 +8,16 @@ describe('updateIntl', () => {
     const messages = {}
     should(updateIntl({locale, messages})).be.eql({
       type: UPDATE,
-      payload: {locale, messages},
+      payload: {locale, messages, formats: undefined},
+    })
+  })
+
+  it('should include formats', () => {
+    const locale = 'it'
+    const formats = {}
+    should(updateIntl({locale, formats})).be.eql({
+      type: UPDATE,
+      payload: {locale, formats, messages: undefined},
     })
   })
 })


### PR DESCRIPTION
This is intended to resolve #24 by forwarding the `formats` key along in the payload of the `updateIntl` action-creator.