### PR TITLE
Option to provide keySelector to #6 workaround

### DIFF
--- a/src/components/IntlProvider.js
+++ b/src/components/IntlProvider.js
@@ -5,12 +5,14 @@ function defaultSelector(state) {
   return state.intl
 }
 
-const mapStateToProps = (state, { intlSelector = defaultSelector }) => {
+function defaultKeySelector(intl) {
+  return intl.locale
+}
+
+const mapStateToProps = (state, { intlSelector = defaultSelector, keySelector = defaultKeySelector }) => {
   const intl = intlSelector(state)
-  return {
-    ...intl,
-    key: intl.locale,
-  }
+  const key = keySelector(intl)
+  return { ...intl, key }
 }
 
 export default connect(mapStateToProps)(IntlProvider)


### PR DESCRIPTION
Unfortunately #6 workaround does not help with the case when only messages change (i.e. after downloading new version from server), but locale stays the same.

This change introduces an option to provide own selector setting the key. There isn't one-size-fits-all solution, as every project has own messages structure, so it cannot be fixed for all.

In my case the solution is as simple as:
```js
const keySelector = (intl) => `${intl.locale}-${JSON.stringify(intl).length}`

...
      <Provider store={store}>
        <IntlProvider keySelector={keySelector}>
```