### PR TITLE
fix: alternate export statement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-export IntlProvider from './components/IntlProvider'
-export Provider from './components/Provider'
+export { default as IntlProvider } from './components/IntlProvider';
+export { default as Provider } from './components/Provider';
 
 export const UPDATE = '@@intl/UPDATE'
 


### PR DESCRIPTION
Hello,
In a vite with react 17, node 18 environment (vite react 16 node 16 I wasn't hitting this on npm start),

I get the following err:
![image](https://github.com/ratson/react-intl-redux/assets/14356838/d82f76a0-3b33-4144-9fff-d25fdf31659f)

Using this import statement in my vite app code-base, and latest ver of react-intl-redux: 
import { IntlProvider } from "react-intl-redux";

The following change resolves the issue and I believe will not cause any regressions.
Would like this to be considered, not sure if its a commonjs issue.

Thanks for taking a look @ratson 